### PR TITLE
Overriding GitHub language classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pro linguist-language=IDL


### PR DESCRIPTION
:wave: I noticed when browsing this project today that GitHub thinks that your project is part IDL, part Prolog. This is because both IDL and Prolog use the `.pro` file extension and GitHub's [Linguist](https://github.com/github/linguist) sometimes gets a little confused.

<img width="994" alt="Screen_Shot_2020-01-31_at_2_13_35_PM" src="https://user-images.githubusercontent.com/4483/73567368-467ff300-4434-11ea-89db-e92f93c5846e.png">

This pull request simply overrides Linguist's language classification, asserting that every `.pro` file is indeed IDL code.

Incorporating this change will result in a language bar that looks like this:

<img width="988" alt="Screen Shot 2020-01-31 at 2 13 54 PM" src="https://user-images.githubusercontent.com/4483/73567398-55ff3c00-4434-11ea-8787-31cbc86cb673.png">

