### PR TITLE
Barycentric correction when dates are not in chronological order

### DIFF
--- a/barycorr/zbarycorr.pro
+++ b/barycorr/zbarycorr.pro
@@ -203,7 +203,7 @@ HPRSTATN, jd_tt, R_ITRF, R_ECI, V_ECI, TBASE=TBASE,USE_EOP=USE_EOP,/jpl, $
 ;; position and velocity of geocenter w.r.t barycenter
 jplfile = find_with_def('JPLEPH.405','ASTRO_DATA')
 if jplfile EQ '' then message,'ERROR - Cannot find JPL ephemeris file' 
-JPLEPHREAD,jplfile,pinfo,pdata,[long(jdtdb[0])-1,long(jdtdb[ntimes-1])+1]+tbase
+JPLEPHREAD,jplfile,pinfo,pdata,[long(min(jdtdb))-1,long(max(jdtdb))+1]+tbase
 JPLEPHINTERP, pinfo, pdata, jdtdb, x,y,z,vx,vy,vz, /EARTH,/VELOCITY, $
               VELUNITS = 'KM/S',tbase=tbase
 

--- a/barycorr/zbarycorr.pro
+++ b/barycorr/zbarycorr.pro
@@ -203,7 +203,9 @@ HPRSTATN, jd_tt, R_ITRF, R_ECI, V_ECI, TBASE=TBASE,USE_EOP=USE_EOP,/jpl, $
 ;; position and velocity of geocenter w.r.t barycenter
 jplfile = find_with_def('JPLEPH.405','ASTRO_DATA')
 if jplfile EQ '' then message,'ERROR - Cannot find JPL ephemeris file' 
-JPLEPHREAD,jplfile,pinfo,pdata,[long(min(jdtdb))-1,long(max(jdtdb))+1]+tbase
+jdmin = long(min(jdtdb + tbase, max=jdmax)) - 1L
+jdmax += 1L
+JPLEPHREAD,jplfile,pinfo,pdata,[jdmin, jdmax]
 JPLEPHINTERP, pinfo, pdata, jdtdb, x,y,z,vx,vy,vz, /EARTH,/VELOCITY, $
               VELUNITS = 'KM/S',tbase=tbase
 


### PR DESCRIPTION
I noticed that that `BARYCORR()` and `ZBARYCORR()` returns incorrect results when input dates are not in chronological order. This small change seems to resolve the issue.

Before (when swapping the dates):
```
IDL> barycorr([2457462.12724721d, 2457535.067362d], 293.08995940d, 69.66117649d, 0.0, pmra=598.07d, pmdec=-1738.40d, px=173.77d, rv=26780.0d, lat=28.2983d, long=-16.5094d, alt=2400.0d )
      -2980.7919277653332
       2544.4863678183606

IDL> barycorr([2457535.067362d, 2457462.12724721d], 293.08995940d, 69.66117649d, 0.0, pmra=598.07d, pmdec=-1738.40d, px=173.77d, rv=26780.0d, lat=28.2983d, long=-16.5094d, alt=2400.0d )
       185.17924426851835
      -2980.7919277653332
```

After:
```
IDL> barycorr([2457462.12724721d, 2457535.067362d], 293.08995940d, 69.66117649d, 0.0, pmra=598.07d, pmdec=-1738.40d, px=173.77d, rv=26780.0d, lat=28.2983d, long=-16.5094d, alt=2400.0d )
      -2980.7919277653332
       2544.4863678183606

IDL> barycorr([2457535.067362d, 2457462.12724721d], 293.08995940d, 69.66117649d, 0.0, pmra=598.07d, pmdec=-1738.40d, px=173.77d, rv=26780.0d, lat=28.2983d, long=-16.5094d, alt=2400.0d )
       2544.4863678183606
      -2980.7919277653332
```